### PR TITLE
fix item30: comma should be used between enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -1672,7 +1672,7 @@ Use it, if multiple enum constants share common behaviors.
 		private enum PayType{
 			WEEKDAY{
 				double overtimePay(double hours, double payRate) { return ...}
-			};
+			},
 			WEEKEND{
 				double overtimePay(double hours, double payRate) { return ...}
 			};


### PR DESCRIPTION
Comma should be used between enum item, rather than semi-colon.